### PR TITLE
Add support for .h / .help

### DIFF
--- a/IRC/contributor-bot.php
+++ b/IRC/contributor-bot.php
@@ -228,6 +228,7 @@ $irc->registerActionHandler( SMARTIRC_TYPE_CHANNEL, '^(!|\.)d(eveloper)?', $doc_
 $irc->registerActionHandler( SMARTIRC_TYPE_CHANNEL, '^(!|\.)c(odex)?', $doc_bot, 'codex' );
 $irc->registerActionHandler( SMARTIRC_TYPE_CHANNEL, '^(!|\.)p(lugin)?', $doc_bot, 'plugin' );
 $irc->registerActionHandler( SMARTIRC_TYPE_CHANNEL, '^(!|\.)g(oogle)?', $doc_bot, 'google' );
+$irc->registerActionHandler( SMARTIRC_TYPE_CHANNEL, '^(!|\.)h(elp)?', $doc_bot, 'help_cmd' );
 
 /**
  * Start the connection to an IRC server

--- a/IRC/doc-bot.php
+++ b/IRC/doc-bot.php
@@ -193,4 +193,16 @@ class DocBot {
 
 		$irc->message( SMARTIRC_TYPE_CHANNEL, $data->channel, $message );
 	}
+	
+	function help_cmd( &$irc, &$data ) {
+		if ( $this->is_doc_bot( $irc, $data->channel ) ) {
+			return;
+		}
+		$msg = $this->message_split( $irc, $data );
+		$google = $this->google_result( $msg->message );
+		$message = sprintf('For ContiBot Help, go to %s',
+			HELP_site
+		);
+		$irc->message( SMARTIRC_TYPE_CHANNEL, $data->channel, $message );
+	}
 }

--- a/config.php
+++ b/config.php
@@ -8,6 +8,7 @@ define( 'BOTPASS', '' );
 define( 'IRC_NETWORK', 'irc.freenode.net' );
 define( 'IRC_PORT', 6667 );
 define( 'IRC_CHANNELS', '#wordpress' );
+define( 'HELP_site', 'http://www.clorith.net/contribot/');
 
 /**
  * Comma separated list of strings used to show appreciation


### PR DESCRIPTION
Added .h(elp) to the command list and a handler, help_cmd
Causes the bot to issue a message pointing to the help page for ContriBot
The help page is set as a define in the config file.